### PR TITLE
Update libraries path to support spaces

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,10 +9,10 @@
 			],
       'conditions': [
         ['OS=="linux"', {
-            "libraries": [ "-L<!(pwd)/libpg_query/linux", "-lpg_query" ]
+            "libraries": [ "-L'<!(pwd)/libpg_query/linux'", "-lpg_query" ]
         } ],
         ['OS=="mac"', {
-          "libraries": [ "-L<!(pwd)/libpg_query/osx", "-lpg_query" ]
+          "libraries": [ "-L'<!(pwd)/libpg_query/osx'", "-lpg_query" ]
         } ],
         ['OS=="win"', { }]
       ]


### PR DESCRIPTION
We implemented pg-query-parser a few days ago, but it broke our Jenkins build because it uses a path with spaces.

This PR simply allows spaces in the path.