### PR TITLE
Fixed vulnerabilities by upgrading dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "url": "git://github.com/zhm/node-pg-query-native.git"
   },
   "devDependencies": {
-    "mocha": "^2.5.3"
+    "mocha": "^9.1.1"
   },
   "dependencies": {
     "bindings": "^1.2.1",
     "nan": "^2.3.5",
-    "node-gyp": "^3.3.1"
+    "node-gyp": "^8.2.0"
   },
   "keywords": [
     "sql",


### PR DESCRIPTION
I upgraded node-gyp and mocha to fix 1 critical and 2 high security vulnerabilities.

The older version of node-gyp was using an old version of tar, where a vulnerability was discovered recently.

And mocha had 1 critical and a few medium vulnerabilities.

All tests past after the dependency upgrade.  

@zhm would appreciate it if you could review and accept if the change looks good.  The pg-query-walker npm module that I maintain depends on this module.